### PR TITLE
[#3] chore : 사용하지 않는 메소드 정리, 기능 변경

### DIFF
--- a/src/main/java/org/classreviewsite/auth/data/Authority.java
+++ b/src/main/java/org/classreviewsite/auth/data/Authority.java
@@ -18,4 +18,9 @@ public class Authority {
     @Column(name = "authority" , length = 50)
     private String authority;
 
+    public static Authority toEntity(String type){
+        return Authority.builder()
+                .authority(type)
+                .build();
+    }
 }

--- a/src/main/java/org/classreviewsite/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/org/classreviewsite/auth/service/CustomUserDetailsService.java
@@ -13,14 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
-/**
- *
- * BadCredentialException : 자격 증명이 없습니다. -> username을 확인해야되는데 email을 확인하는 오류
- * 코드는 끝까지 따라쳐라
- * 메서드 파헤치다가 안보이면 소스 다운받기 누르면 설명도 추가됨
- * 에러 해결 : https://yoonsys.tistory.com/33
- */
-
 @Component("userDetailService")
 public class CustomUserDetailsService implements UserDetailsService {
 

--- a/src/main/java/org/classreviewsite/classlist/data/UserClassList.java
+++ b/src/main/java/org/classreviewsite/classlist/data/UserClassList.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.classreviewsite.lecture.data.Lecture;
 import org.classreviewsite.user.data.User;
 
 @NoArgsConstructor
@@ -12,7 +13,7 @@ import org.classreviewsite.user.data.User;
 @Builder
 @Getter
 @Entity
-@Table(name = "UserClassList", uniqueConstraints = @UniqueConstraint(columnNames = {"classNumber", "userNumber"}))
+@Table(name = "UserClassList")
 public class UserClassList {
 
     // 수강한 고유 번호
@@ -43,8 +44,11 @@ public class UserClassList {
 
     // 어떤 교과목
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "classNumber")
-    private ClassList classNumber;
+    @JoinColumn(nullable = false)
+    private Lecture lecture;
+
+    @Column(nullable = true, length = 45, unique = false)
+    private String professor;
 
 
 }

--- a/src/main/java/org/classreviewsite/classlist/dto/response/UserClassListResponse.java
+++ b/src/main/java/org/classreviewsite/classlist/dto/response/UserClassListResponse.java
@@ -13,46 +13,22 @@ import java.util.List;
 @Builder
 public class UserClassListResponse {
 
-    private Long CompletionNumber;
-
     private String CompletionYear;
-
     private String CompletionType;
-
-    private String grade;
-
     private String semester;
-
     private Long classNumber;
-
     private String lectureName;
-
     private String professorName;
-
-    public static List<UserClassListResponse> toList(List<UserClassList> list){
-        List<UserClassListResponse> result = new ArrayList<>();
-        for(UserClassList userClassList : list){
-            result.add(
-                UserClassListResponse.from(userClassList)
-            );
-        }
-        return result;
-    }
 
     public static UserClassListResponse from(UserClassList userClassList){
         return UserClassListResponse.builder()
-                .classNumber(userClassList.getClassNumber().getClassNumber())
+                .classNumber(userClassList.getLecture().getLectureId())
                 .semester(userClassList.getSemester())
-                .grade(userClassList.getGrade())
                 .CompletionType(userClassList.getCompletionType())
                 .CompletionYear(userClassList.getCompletionYear())
-                .CompletionNumber(userClassList.getCompletionNumber())
-                .lectureName(userClassList.getClassNumber().getLecture().getLectureName())
-                .professorName(userClassList.getClassNumber().getProfessor().getProfessorName())
+                .lectureName(userClassList.getLecture().getLectureName())
+                .professorName(userClassList.getProfessor())
                 .build();
     }
-
-
-
 
 }

--- a/src/main/java/org/classreviewsite/classlist/infrastructure/UserClassListDataRepository.java
+++ b/src/main/java/org/classreviewsite/classlist/infrastructure/UserClassListDataRepository.java
@@ -1,5 +1,7 @@
 package org.classreviewsite.classlist.infrastructure;
 
+import org.classreviewsite.classlist.data.ClassList;
+import org.classreviewsite.lecture.data.Lecture;
 import org.classreviewsite.user.data.User;
 import org.classreviewsite.classlist.data.UserClassList;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,7 +17,9 @@ public interface UserClassListDataRepository extends JpaRepository<UserClassList
 
     Optional<List<UserClassList>> findByUserNumber(@Param("userNumber") User userNumber);
 
-    @Query("select m from UserClassList m join fetch m.userNumber and join fetch m.classNumber where m.userNumber.userNumber = :userNumber")
+    Optional<UserClassList> findByUserNumberAndLecture(@Param("userNumber") User userNumber, @Param("lecture") Lecture lectureNumber);
+
+    @Query("select m from UserClassList m join fetch m.userNumber and join fetch m.lecture where m.userNumber.userNumber = :userNumber")
     List<UserClassList> findByUserNumberWithClassAndUser(@Param("userNumber") int userNumber);
 
 

--- a/src/main/java/org/classreviewsite/classlist/service/UserClassListService.java
+++ b/src/main/java/org/classreviewsite/classlist/service/UserClassListService.java
@@ -39,7 +39,7 @@ public class UserClassListService {
             throw new UserNotFoundException("해당 학생이 수강한 강의는 없습니다.");
         }
 
-        return UserClassListResponse.toList(list);
+        return list.stream().map(UserClassListResponse::from).toList();
 
     }
 
@@ -50,6 +50,15 @@ public class UserClassListService {
         List<UserClassList> list = userClassListDataRepository.findByUserNumber(user).orElseThrow(() -> new ClassNotFoundException("해당 학생이 수강한 강의가 없습니다."));
 
         return MyPageStudentInfo.from(list);
+    }
+
+    @Transactional(readOnly = true)
+    public UserClassList findByUserNumber(int userNumber, String lectureName){
+        User user = userService.findById(Long.valueOf(userNumber));
+        Lecture lecture = lectureService.findByLectureName(lectureName);
+        UserClassList list = userClassListDataRepository.findByUserNumberAndLecture(user, lecture).orElseThrow(() -> new NoPermissionReviewException(""));
+        System.out.println(list.getUserNumber());
+        return list;
     }
 
 

--- a/src/main/java/org/classreviewsite/classlist/service/UserClassListService.java
+++ b/src/main/java/org/classreviewsite/classlist/service/UserClassListService.java
@@ -2,18 +2,18 @@ package org.classreviewsite.classlist.service;
 
 import lombok.RequiredArgsConstructor;
 import org.classreviewsite.auth.exception.ClassNotFoundException;
+import org.classreviewsite.auth.exception.NoPermissionReviewException;
 import org.classreviewsite.auth.exception.UserNotFoundException;
 import org.classreviewsite.classlist.dto.response.MyPageStudentInfo;
 import org.classreviewsite.classlist.dto.response.UserClassListResponse;
 import org.classreviewsite.classlist.infrastructure.UserClassListDataRepository;
+import org.classreviewsite.lecture.data.Lecture;
+import org.classreviewsite.lecture.service.LectureService;
 import org.classreviewsite.user.data.User;
 import org.classreviewsite.classlist.data.UserClassList;
-import org.classreviewsite.user.infrastructure.UserDataRepository;
 import org.classreviewsite.user.service.UserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -24,6 +24,7 @@ public class UserClassListService {
     private final UserClassListDataRepository userClassListDataRepository;
 
     private final UserService userService;
+    private final LectureService lectureService;
 
 
     @Transactional

--- a/src/main/java/org/classreviewsite/classlist/service/UserClassListService.java
+++ b/src/main/java/org/classreviewsite/classlist/service/UserClassListService.java
@@ -45,7 +45,7 @@ public class UserClassListService {
 
     @Transactional(readOnly = true)
     public List<MyPageStudentInfo> myPageWithStudent(int userNumber){
-        User user = userService.findById(Long.valueOf(userNumber)).orElseThrow(() -> new UserNotFoundException("해당 학생을 찾을 수 없습니다."));
+        User user = userService.findById(Long.valueOf(userNumber));
 
         List<UserClassList> list = userClassListDataRepository.findByUserNumber(user).orElseThrow(() -> new ClassNotFoundException("해당 학생이 수강한 강의가 없습니다."));
 

--- a/src/main/java/org/classreviewsite/user/controller/UserController.java
+++ b/src/main/java/org/classreviewsite/user/controller/UserController.java
@@ -46,16 +46,9 @@ public class UserController {
     @ApiResponse(responseCode = "401", description = "학번은 8자리입니다.")
     @ApiResponse(responseCode = "401", description = "아이디 및 비밀번호를 확인해주세요")
     public Result signIn(@Parameter(required = true, description = "학번, 비밀번호 요청") @RequestBody LoginUserRequest dto, HttpServletResponse response){
-        log.info("password: {}", passwordEncoder.encode(dto.getPassword()));
 
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(dto.getUserNumber(), dto.getPassword());
-
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-
-//        log.info("인증: {}", authentication);
-//        log.info("로그인: {}", authentication.getName());
-        log.info("로그인2: {}", authentication.getAuthorities());
-
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         String token = jwtTokenProvider.createToken(authentication);
@@ -67,11 +60,10 @@ public class UserController {
 
 
     @PostMapping("/signup")
-    @Operation(summary = "회원가입 요청", description = "회원가입을 요청합니다.")
+    @Operation(summary = "회원가입 요청", description = "회원가입을 요청합니다. userType : 'STUDENT' , 'PROFESSOR' 중에 하나 주시면 처리하도록 하겠습니다.")
     @ApiResponse(responseCode = "200", description = "회원가입이 완료되었습니다.")
     @ApiResponse(responseCode = "204", description = "이미 존재하는 학생입니다.")
     public Result signUp( @RequestBody CreateUserRequest dto){
-        log.info("회원가입: {}" , dto);
         userService.signUp(dto);
         return new Result<>(200, dto, "회원가입이 완료되었습니다.");
     }

--- a/src/main/java/org/classreviewsite/user/data/User.java
+++ b/src/main/java/org/classreviewsite/user/data/User.java
@@ -43,12 +43,13 @@ public class User {
     )
     private Set<Authority> authorities;
 
-    public static User toEntity(CreateUserRequest user, String password){
+    public static User toEntity(CreateUserRequest user, String password, Authority authority){
         return User.builder()
                 .userNumber(user.getUserNumber())
                 .userName(user.getUserName())
                 .department(user.getDepartment())
                 .nickname(user.getNickname())
+                .authorities(Collections.singleton(authority))
                 .password(password)
                 .build();
     }

--- a/src/main/java/org/classreviewsite/user/data/User.java
+++ b/src/main/java/org/classreviewsite/user/data/User.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.classreviewsite.auth.data.Authority;
 import org.classreviewsite.user.dto.CreateUserRequest;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.Collections;
 import java.util.Set;
 
 @NoArgsConstructor

--- a/src/main/java/org/classreviewsite/user/dto/CreateUserRequest.java
+++ b/src/main/java/org/classreviewsite/user/dto/CreateUserRequest.java
@@ -21,5 +21,7 @@ public class CreateUserRequest {
 
     private String nickname;
 
+    private String userType;
+
 
 }

--- a/src/main/java/org/classreviewsite/user/service/UserService.java
+++ b/src/main/java/org/classreviewsite/user/service/UserService.java
@@ -2,6 +2,9 @@ package org.classreviewsite.user.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.classreviewsite.auth.data.Authority;
+import org.classreviewsite.auth.exception.UserNotFoundException;
+import org.classreviewsite.auth.service.AuthService;
 import org.classreviewsite.user.dto.CreateUserRequest;
 import org.classreviewsite.user.data.User;
 import org.classreviewsite.auth.exception.UserExistException;
@@ -20,37 +23,31 @@ public class UserService {
 
     private final UserDataRepository userDataRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthService authService;
 
     @Transactional(readOnly = true)
-    public Optional<User> findById(Long userNumber){
-        return userDataRepository.findById(userNumber);
+    public User findById(Long userNumber){
+        return userDataRepository.findById(userNumber).orElseThrow(() -> new UserNotFoundException("해당 학생이 존재하지 않습니다."));
     }
-
 
     @Transactional
-    public void signUp(CreateUserRequest user){
+    public int signUp(CreateUserRequest user){
 
         validateDuplicateUser(user);
-
         String password = passwordEncoder.encode(user.getPassword());
 
-        userDataRepository.save(User.toEntity(user, password));
+        Authority authority = Authority.toEntity(user.getUserType());
+        int userNumber =  userDataRepository.save(User.toEntity(user, password, authority)).getUserNumber();
+
+        return userNumber;
+
 
     }
 
-
     private void validateDuplicateUser(CreateUserRequest user){
-
        userDataRepository.findByUserNumber(user.getUserNumber())
                .ifPresent(m -> {
             throw new UserExistException("이미 존재하는 학생입니다.");
         });
-
-
     }
-
-
-
-
-
 }


### PR DESCRIPTION
- 사용하지 않는 메소드 정리
- 쿼리 변경
- 연관관계 ClassList -> Lecture 로 변경
- toEntity 메소드 인증 정보도 포함되도록 변경
- import 패키지 정리
- 회원가입 메소드 인증정보도 추가되도록 변경, findById 예외처리
- 주석제거, 인증 정보 핸들링 추가, swagger 문서 수정
- 학번으로 조회하는 메소드 추가
- findById 예외처리를 추가하였으므로 제거
- 필요한 패키지 추가
- toEntity 메소드 추가
- 주석제거
- 클라이언트가 판단하기 위한 유저 타입 멤버변수 추가